### PR TITLE
Fix build issues in precheck and capture modules

### DIFF
--- a/android/app/src/main/kotlin/com/example/pockyc/capture/ImageProxyExtensions.kt
+++ b/android/app/src/main/kotlin/com/example/pockyc/capture/ImageProxyExtensions.kt
@@ -1,0 +1,35 @@
+package com.example.pockyc.capture
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ImageFormat
+import android.graphics.Rect
+import android.graphics.YuvImage
+import androidx.camera.core.ImageProxy
+import java.io.ByteArrayOutputStream
+
+fun ImageProxy.toBitmap(): Bitmap {
+    val yBuffer = planes[0].buffer
+    val uBuffer = planes[1].buffer
+    val vBuffer = planes[2].buffer
+
+    yBuffer.rewind()
+    uBuffer.rewind()
+    vBuffer.rewind()
+
+    val ySize = yBuffer.remaining()
+    val uSize = uBuffer.remaining()
+    val vSize = vBuffer.remaining()
+
+    val nv21 = ByteArray(ySize + uSize + vSize)
+    yBuffer.get(nv21, 0, ySize)
+    vBuffer.get(nv21, ySize, vSize)
+    uBuffer.get(nv21, ySize + vSize, uSize)
+
+    val yuvImage = YuvImage(nv21, ImageFormat.NV21, width, height, null)
+    val out = ByteArrayOutputStream()
+    yuvImage.compressToJpeg(Rect(0, 0, width, height), 100, out)
+    val imageBytes = out.toByteArray()
+    out.close()
+    return BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+}

--- a/android/app/src/main/kotlin/com/example/pockyc/precheck/Config.kt
+++ b/android/app/src/main/kotlin/com/example/pockyc/precheck/Config.kt
@@ -5,5 +5,5 @@ object Config {
     var EXPOSURE_MIN = 60
     var EXPOSURE_MAX = 200
     var MOTION_MAX = 1.5
-    var FACE_STABILITY = 3.0
+    var FACE_STABILITY = 0.5
 }

--- a/android/app/src/main/kotlin/com/example/pockyc/transport/TransportSecurityManager.kt
+++ b/android/app/src/main/kotlin/com/example/pockyc/transport/TransportSecurityManager.kt
@@ -15,9 +15,11 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 import java.security.cert.X509Certificate
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
 
 class TransportSecurityManager {
@@ -122,9 +124,10 @@ class TransportSecurityManager {
                 multipartBody.addFormDataPart(
                     "chunk_${chunk.chunkIndex}",
                     "chunk_${chunk.chunkIndex}.bin",
-                    okhttp3.RequestBody.create(okhttp3.MediaType.parse("application/octet-stream"), chunk.data)
-                ).addFormDataPart("hmac_${chunk.chunkIndex}", chunk.hmac)
-                .addFormDataPart("sha256_${chunk.chunkIndex}", chunk.sha256)
+                    chunk.data.toRequestBody("application/octet-stream".toMediaType())
+                )
+                    .addFormDataPart("hmac_${chunk.chunkIndex}", chunk.hmac)
+                    .addFormDataPart("sha256_${chunk.chunkIndex}", chunk.sha256)
             }
 
             val request = Request.Builder()
@@ -168,14 +171,14 @@ class TransportSecurityManager {
                 .addFormDataPart(
                     "selfie",
                     selfieFile.name,
-                    okhttp3.RequestBody.create(okhttp3.MediaType.parse("video/mp4"), selfieData)
+                    selfieData.toRequestBody("video/mp4".toMediaType())
                 )
                 .addFormDataPart("selfie_hmac", selfieHmac)
                 .addFormDataPart("selfie_sha256", selfieSha256)
                 .addFormDataPart(
                     "id_video",
                     idFile.name,
-                    okhttp3.RequestBody.create(okhttp3.MediaType.parse("video/mp4"), idData)
+                    idData.toRequestBody("video/mp4".toMediaType())
                 )
                 .addFormDataPart("id_hmac", idHmac)
                 .addFormDataPart("id_sha256", idSha256)
@@ -188,7 +191,7 @@ class TransportSecurityManager {
 
             val response: Response = client.newCall(request).execute()
             if (response.isSuccessful) {
-                val responseBody = response.body()?.string()
+                val responseBody = response.body?.string()
                 response.close()
                 responseBody
             } else {

--- a/android/app/src/main/kotlin/com/example/pockyc/ui/CameraPreview.kt
+++ b/android/app/src/main/kotlin/com/example/pockyc/ui/CameraPreview.kt
@@ -1,16 +1,10 @@
 package com.example.pockyc.ui
 
-import android.util.Log
 import androidx.camera.view.PreviewView
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
 import com.example.pockyc.capture.CameraManager
-import kotlinx.coroutines.launch
 
 @Composable
 fun CameraPreview(modifier: Modifier = Modifier, cameraManager: CameraManager) {

--- a/android/app/src/main/kotlin/com/example/pockyc/ui/CaptureScreen.kt
+++ b/android/app/src/main/kotlin/com/example/pockyc/ui/CaptureScreen.kt
@@ -1,5 +1,6 @@
 package com.example.pockyc.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
@@ -10,11 +11,14 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.pockyc.R
 import com.example.pockyc.capture.CaptureState
 import com.example.pockyc.capture.CaptureViewModel
+import com.example.pockyc.capture.CameraManager
 import com.example.pockyc.capture.Challenge
+import java.io.File
 
 @Composable
 fun CaptureScreen(viewModel: CaptureViewModel = viewModel(), initialDebugMode: Boolean = false) {
@@ -105,9 +109,8 @@ fun GuideScreen(message: String, viewModel: CaptureViewModel) {
 fun RecordingScreen(challenge: Challenge?, viewModel: CaptureViewModel) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
-    val coroutineScope = rememberCoroutineScope()
 
-    val cameraManager = remember { CameraManager(context, lifecycleOwner, viewModel.precheckManager) }
+    val cameraManager = remember(context, lifecycleOwner) { CameraManager(context, lifecycleOwner, viewModel.precheckManager) }
 
     LaunchedEffect(Unit) {
         cameraManager.initializeCamera()
@@ -238,15 +241,15 @@ fun DebugPanel(viewModel: CaptureViewModel) {
 
         // FACE_STABILITY slider
         var faceStability by remember { mutableStateOf(com.example.pockyc.precheck.Config.FACE_STABILITY.toFloat()) }
-        Text("FACE_STABILITY: ${faceStability}")
+        Text(String.format("FACE_STABILITY: %.2f", faceStability))
         Slider(
             value = faceStability,
             onValueChange = {
                 faceStability = it
                 com.example.pockyc.precheck.Config.FACE_STABILITY = it.toDouble()
             },
-            valueRange = 1f..10f,
-            steps = 90
+            valueRange = 0f..1f,
+            steps = 9
         )
     }
 }


### PR DESCRIPTION
## Summary
- lazily initialize the MediaPipe face detector with a context, replace invalid OpenCV calls, and rely on detection confidence for face stability checks
- add an ImageProxy→Bitmap converter, improve camera preview initialization, and hook the precheck manager into the analyzer with a context
- migrate OkHttp usage to modern extension APIs and align the debug slider range with the new face confidence threshold

## Testing
- `./gradlew :app:assembleDebug` *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db44f560ac832da8ef6e63cac30ef2