### PR TITLE
Fix OpenCV dependency incompatibility

### DIFF
--- a/server/worker/requirements.txt
+++ b/server/worker/requirements.txt
@@ -1,8 +1,8 @@
 celery==5.3.4
 redis==5.0.1
 requests==2.31.0
-opencv-python==4.8.1.78
-numpy<2.0
+opencv-python-headless==4.8.1.78
+numpy==1.26.4
 minio==7.1.17
 sqlalchemy==2.0.23
 psycopg2-binary==2.9.9


### PR DESCRIPTION
## Summary
- align the worker dependencies with a fixed numpy build and headless OpenCV distribution to avoid runtime import failures

## Testing
- pip install -r server/worker/requirements.txt *(fails: blocked from downloading packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db6401c3ac832d9e632509509dc899