### PR TITLE
fix(android): Standardize OpenCV initialization to fix build

### DIFF
--- a/android/app/src/main/kotlin/com/example/pockyc/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/pockyc/MainActivity.kt
@@ -10,14 +10,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.example.pockyc.ui.CaptureScreen
-import nu.pattern.OpenCV
+import org.opencv.android.OpenCVLoader
 
 class MainActivity : ComponentActivity() {
 
     companion object {
         init {
             System.loadLibrary("mediapipe_tasks_vision_jni")
-            OpenCV.loadShared()
+            OpenCVLoader.initDebug()
         }
     }
 


### PR DESCRIPTION
The Android application failed to build due to "Unresolved reference" errors for `android` and `Utils` in `PrecheckManager.kt`.

These errors were caused by a dependency conflict between two different OpenCV libraries being used in the project: `nu.pattern.OpenCV` was used for initialization in `MainActivity.kt`, while the rest of the app depended on `org.openpnp:opencv:4.9.0-0`.

This commit resolves the conflict by updating `MainActivity.kt` to use the correct initialization method, `OpenCVLoader.initDebug()`, from the `org.opencv.android` package. This aligns the initialization with the project's dependencies, resolving the build errors.